### PR TITLE
Document HexiDirect rule processing substeps

### DIFF
--- a/docs/FUNCTIONAL_REQUIREMENTS.md
+++ b/docs/FUNCTIONAL_REQUIREMENTS.md
@@ -21,7 +21,7 @@
 - The system shall expand macro rules into concrete directional variants prior to evaluation.
 - The system shall apply grouped random selection when multiple rules arising from the same macro expansion match a cell.
 - The system shall evaluate rule conditions against the six neighbors in clockwise order.
-- The system shall process rules in two substeps: `select_applicable_rules` collects all matching rules per cell, and `apply_random_rules` randomly chooses one rule to apply to each cell.
+- The system shall process rules in two substeps: `select_applicable_rules` gathers all matching rules for each cell, and `apply_random_rules` randomly selects one rule to apply to each cell.
 - The system shall apply at most one resulting transformation per cell per step.
 ## Graphical User Interface
 - The system shall provide a graphical user interface.

--- a/docs/FUNCTIONAL_REQUIREMENTS.md
+++ b/docs/FUNCTIONAL_REQUIREMENTS.md
@@ -21,6 +21,7 @@
 - The system shall expand macro rules into concrete directional variants prior to evaluation.
 - The system shall apply grouped random selection when multiple rules arising from the same macro expansion match a cell.
 - The system shall evaluate rule conditions against the six neighbors in clockwise order.
+- The system shall process rules in two substeps: `select_applicable_rules` collects all matching rules per cell, and `apply_random_rules` randomly chooses one rule to apply to each cell.
 - The system shall apply at most one resulting transformation per cell per step.
 ## Graphical User Interface
 - The system shall provide a graphical user interface.


### PR DESCRIPTION
## Summary
- clarify HexiDirect rule processing occurs in two steps: select_applicable_rules and apply_random_rules

## Testing
- `python -m black docs/FUNCTIONAL_REQUIREMENTS.md` *(fails: cannot parse Markdown)*
- `python tools/run_tests.py --no-gui`
- `HEXIRULES_NO_GUI=1 python tools/check_quality.py`


------
https://chatgpt.com/codex/tasks/task_e_6899f53827a4832594b585ecee2a4abc