### PR TITLE
Add interactive command-line interface and tests

### DIFF
--- a/docs/CLI_HOWTO.md
+++ b/docs/CLI_HOWTO.md
@@ -1,0 +1,37 @@
+# CLI How-To
+
+The HexiRules command-line interface lets you configure and run worlds
+without the GUI.
+
+## Starting the shell
+
+```
+python src/cli.py --rule B3/S23 --radius 3
+```
+
+Use `--rule` to choose the starting rule and `--radius` for grid size.
+
+## Core commands
+
+- `rule [RULE]` – set or show the current rule
+- `rules` – list all rules
+- `set Q R STATE` – set a cell state (1 alive, 0 dead)
+- `toggle Q R` – toggle a cell
+- `query Q R` – print cell state
+- `summary` – show alive cell count
+- `cells` – list alive cell coordinates
+- `grid [RADIUS]` – print grid in ASCII
+- `step [N]` – advance N generations
+- `clear` – clear all cells
+- `exit` – leave the shell
+
+## HexiDirect rules
+
+HexiDirect notation is also supported. Example:
+
+```
+python src/cli.py --rule "a=>_"
+```
+
+The same commands apply. Active cells default to state `a` with
+direction `1` when using `set` or `toggle`.

--- a/docs/FUNCTIONAL_REQUIREMENTS.md
+++ b/docs/FUNCTIONAL_REQUIREMENTS.md
@@ -49,3 +49,10 @@
 - The system shall display status including world name, active cell count, and a compact rules summary.
 - The system shall log rule parsing, expansion, applications, and step summaries in a scrollable log.
 - The system shall allow clearing the log.
+
+## Command-Line Interface
+- The system shall provide a command-line interface for running the automaton.
+- The CLI shall allow setting rules, editing cell states, and advancing steps.
+- The CLI shall allow querying individual cell states.
+- The CLI shall display active rules and list all live cells on request.
+- The CLI shall render the current grid as ASCII art.

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,69 +1,139 @@
 #!/usr/bin/env python3
-"""
-Command-line interface for HexiRules.
-Provides text-based interaction with the hexagonal cellular automaton.
+"""Command-line interface for HexiRules.
+
+Provides an interactive shell for configuring and running the automaton.
 """
 
+from __future__ import annotations
+
 import argparse
-import time
+import cmd
+from typing import Iterable, Sequence
+
 from automaton import Automaton
 from version import __version__
 
 
-def print_grid(automaton: Automaton, radius: int = 3) -> None:
-    """Print the current state of the automaton as text."""
-    print("\nCurrent State:")
+def grid_to_ascii(automaton: Automaton, radius: int = 3) -> str:
+    """Return the current grid state as ASCII art."""
+    lines = []
     for r in range(-radius, radius + 1):
         spaces = " " * abs(r)
         line = []
         for q in range(-radius, radius + 1):
             if abs(q + r) <= radius:
-                if (q, r) in automaton.state:
-                    line.append("●")
-                else:
-                    line.append("○")
-        print(spaces + " ".join(line))
+                line.append("●" if (q, r) in automaton.state else "○")
+        lines.append(spaces + " ".join(line))
+    return "\n".join(lines)
 
 
-def main() -> None:
+def print_grid(automaton: Automaton, radius: int = 3) -> None:
+    """Print the grid to standard output."""
+    print(grid_to_ascii(automaton, radius))
+
+
+class HexCLI(cmd.Cmd):
+    """Interactive command shell for the automaton."""
+
+    intro = f"HexiRules v{__version__}. Type 'help' for commands."
+    prompt = "hex> "
+
+    def __init__(self, automaton: Automaton, stdout=None):
+        super().__init__(stdout=stdout)
+        self.automaton = automaton
+
+    # --- Commands -------------------------------------------------
+    def do_rule(self, arg: str) -> None:
+        """rule [RULE] - set or show the current rule."""
+        rule = arg.strip()
+        if rule:
+            self.automaton.set_rule(rule)
+            print(f"Rule set to {self.automaton.rule}", file=self.stdout)
+        else:
+            self.do_rules(arg)
+
+    def do_rules(self, arg: str) -> None:  # noqa: D401 - simple wrapper
+        """rules - list applied rules."""
+        if self.automaton.use_hex_rules and self.automaton.hex_automaton:
+            for rule in self.automaton.hex_automaton.rules:
+                print(rule.rule_str, file=self.stdout)
+        else:
+            print(self.automaton.rule, file=self.stdout)
+
+    def do_set(self, arg: str) -> None:
+        """set Q R STATE - set cell state (1 alive, 0 dead)."""
+        parts = arg.split()
+        if len(parts) != 3:
+            print("Usage: set Q R STATE", file=self.stdout)
+            return
+        q, r, state = parts
+        self.automaton.set_cell_state(int(q), int(r), state)
+        print(f"Cell {q} {r} set to {state}", file=self.stdout)
+
+    def do_toggle(self, arg: str) -> None:
+        """toggle Q R - toggle a cell."""
+        parts = arg.split()
+        if len(parts) != 2:
+            print("Usage: toggle Q R", file=self.stdout)
+            return
+        q, r = map(int, parts)
+        self.automaton.toggle_cell(q, r)
+        print(f"Toggled {q} {r}", file=self.stdout)
+
+    def do_query(self, arg: str) -> None:
+        """query Q R - get cell state."""
+        parts = arg.split()
+        if len(parts) != 2:
+            print("Usage: query Q R", file=self.stdout)
+            return
+        q, r = map(int, parts)
+        print(self.automaton.get_cell_state(q, r), file=self.stdout)
+
+    def do_summary(self, arg: str) -> None:  # noqa: D401 - simple wrapper
+        """summary - show number of alive cells."""
+        print(f"Alive cells: {len(self.automaton.state)}", file=self.stdout)
+
+    def do_cells(self, arg: str) -> None:  # noqa: D401 - simple wrapper
+        """cells - list coordinates of alive cells."""
+        for q, r in sorted(self.automaton.state):
+            print(f"{q} {r}", file=self.stdout)
+
+    def do_grid(self, arg: str) -> None:
+        """grid [RADIUS] - print grid state."""
+        radius = int(arg.strip()) if arg.strip() else self.automaton.radius
+        print(grid_to_ascii(self.automaton, radius), file=self.stdout)
+
+    def do_step(self, arg: str) -> None:
+        """step [N] - advance N generations."""
+        n = int(arg.strip()) if arg.strip() else 1
+        for _ in range(n):
+            self.automaton.step()
+        print(f"Stepped {n}", file=self.stdout)
+
+    def do_clear(self, arg: str) -> None:  # noqa: D401 - simple wrapper
+        """clear - remove all cells."""
+        self.automaton.clear()
+        print("Cleared", file=self.stdout)
+
+    def do_exit(self, arg: str) -> bool:  # noqa: D401 - simple wrapper
+        """exit - quit the shell."""
+        return True
+
+    do_quit = do_exit
+    do_EOF = do_exit
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the command-line interface."""
     parser = argparse.ArgumentParser(
         description=f"HexiRules v{__version__} - Hexagonal Cellular Automaton CLI"
     )
-    parser.add_argument(
-        "--version", action="version", version=f"HexiRules {__version__}"
-    )
     parser.add_argument("--rule", default="B3/S23", help="CA rule (e.g., B3/S23)")
-    parser.add_argument(
-        "--steps", type=int, default=10, help="Number of steps to simulate"
-    )
-    parser.add_argument(
-        "--delay", type=float, default=0.5, help="Delay between steps (seconds)"
-    )
     parser.add_argument("--radius", type=int, default=3, help="Grid radius")
+    args = parser.parse_args(argv)
 
-    args = parser.parse_args()
-
-    automaton = Automaton(args.rule)
-
-    # Set up initial pattern (simple test pattern)
-    automaton.toggle_cell(0, 0)
-    automaton.toggle_cell(1, 0)
-    automaton.toggle_cell(0, 1)
-
-    print(f"HexiRules v{__version__} CLI - Rule: {args.rule}")
-    print(f"Simulating {args.steps} steps with {args.delay}s delay")
-
-    print_grid(automaton, args.radius)
-
-    for step in range(args.steps):
-        time.sleep(args.delay)
-        automaton.step()
-        print(f"\n--- Step {step + 1} ---")
-        print_grid(automaton, args.radius)
-
-        if not automaton.state:
-            print("All cells died - ending simulation")
-            break
+    automaton = Automaton(radius=args.radius, rule=args.rule)
+    HexCLI(automaton).cmdloop()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,15 @@ class TestCLI(unittest.TestCase):
         summary_output = run_cmd(self.cli, "summary")
         self.assertIn("0", summary_output)
 
+    def test_hex_rule_mode(self) -> None:
+        cli = HexCLI(Automaton(radius=3, rule="a=>_"), stdout=io.StringIO())
+        rules_output = run_cmd(cli, "rules")
+        self.assertIn("a=>_", rules_output)
+        run_cmd(cli, "set 0 0 1")
+        self.assertEqual("1", run_cmd(cli, "query 0 0"))
+        run_cmd(cli, "step")
+        self.assertEqual("0", run_cmd(cli, "query 0 0"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+import io
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from automaton import Automaton
+from cli import HexCLI
+
+
+def run_cmd(cli: HexCLI, command: str) -> str:
+    buffer = io.StringIO()
+    cli.stdout = buffer
+    cli.onecmd(command)
+    return buffer.getvalue().strip()
+
+
+class TestCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        automaton = Automaton(radius=3, rule="B3/S23")
+        self.cli = HexCLI(automaton, stdout=io.StringIO())
+
+    def test_rule_management(self) -> None:
+        run_cmd(self.cli, "rule B2/S3")
+        output = run_cmd(self.cli, "rules")
+        self.assertIn("B2/S3", output)
+
+    def test_cell_operations_and_summary(self) -> None:
+        run_cmd(self.cli, "set 0 0 1")
+        run_cmd(self.cli, "set 1 0 1")
+        run_cmd(self.cli, "set 0 1 1")
+        query_output = run_cmd(self.cli, "query 0 0")
+        self.assertEqual("1", query_output)
+        cells_output = run_cmd(self.cli, "cells")
+        self.assertIn("0 0", cells_output)
+        summary_output = run_cmd(self.cli, "summary")
+        self.assertIn("3", summary_output)
+        grid_output = run_cmd(self.cli, "grid 1")
+        self.assertIn("●", grid_output)
+
+    def test_step_progression(self) -> None:
+        run_cmd(self.cli, "set 0 0 1")
+        run_cmd(self.cli, "step")
+        summary_output = run_cmd(self.cli, "summary")
+        self.assertIn("0", summary_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace simple CLI with interactive shell supporting rule updates, cell editing, stepping, querying, summaries, and ASCII grid display
- Add command-line requirements to functional specification
- Test CLI commands for rule management, cell operations, summaries, grids, and stepping

## Testing
- `python tools/run_tests.py --no-gui`
- `HEXIRULES_NO_GUI=1 python tools/check_quality.py`


------
https://chatgpt.com/codex/tasks/task_e_6899ff6f9210832594d1ffe8dc562bc1