### PR TITLE
Format hex rules and annotate replacer function

### DIFF
--- a/src/hex_rules.py
+++ b/src/hex_rules.py
@@ -5,7 +5,7 @@ Implements the custom rule notation for hexagonal cellular automata
 
 import random
 import re
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Match, Optional, Set, Tuple
 
 
 class HexCell:
@@ -183,7 +183,7 @@ class HexAutomaton:
                     expanded_src: List[str] = []
                     for direction in range(1, 7):
 
-                        def _repl(m: re.Match[str], d: int = direction) -> str:
+                        def _repl(m: Match[str], d: int = direction) -> str:
                             return f"{m.group(1)}{d}"
 
                         new_source = re.sub(

--- a/src/hex_rules.py
+++ b/src/hex_rules.py
@@ -183,10 +183,13 @@ class HexAutomaton:
                     expanded_src: List[str] = []
                     for direction in range(1, 7):
 
+                        def _repl(m: re.Match[str], d: int = direction) -> str:
+                            return f"{m.group(1)}{d}"
+
                         new_source = re.sub(
-                            r"([a-z_]+)%", 
-                            lambda m, d=direction: f"{m.group(1)}{d}", 
-                            source_part
+                            r"([a-z_]+)%",
+                            _repl,
+                            source_part,
                         )
                         expanded_src.append(f"{new_source} => {target_part}")
                     rules = expanded_src


### PR DESCRIPTION
## Summary
- format hex rules module with Black
- replace regex lambda with typed helper for MyPy

## Testing
- `python tools/run_tests.py --no-gui`
- `HEXIRULES_NO_GUI=1 python tools/check_quality.py`


------
https://chatgpt.com/codex/tasks/task_e_689a4f8a7c8883259f855e2bf0f77bcc