### PR TITLE
Handle missing world in ASCII control panel

### DIFF
--- a/docs/FUNCTIONAL_REQUIREMENTS.md
+++ b/docs/FUNCTIONAL_REQUIREMENTS.md
@@ -44,6 +44,9 @@
 - The panel shall allow entering rules.
 - The panel shall allow advancing the automaton by one step.
 - The panel shall allow clearing all cells.
+- The panel shall render placeholder content when no world is selected.
+- The ASCII renderer shall expose tagged per-character output for automated
+  visualization tests.
 
 ## Execution and Status
 - The system shall execute a single simulation step on demand.

--- a/src/infrastructure/ui/hexios/desktop/ascii/viewmodel.py
+++ b/src/infrastructure/ui/hexios/desktop/ascii/viewmodel.py
@@ -105,7 +105,31 @@ class AsciiViewModel:
     def from_controller(
         controller: WorldService, selected_info: Optional[str] = None
     ) -> "AsciiViewModel":
-        world = controller.get_current_world()
+        try:
+            world = controller.get_current_world()
+        except RuntimeError:
+            header_f = HeaderVM().to_frame()
+            worlds_f = FrameVM(
+                id="worlds",
+                title="Worlds",
+                hotkey="w",
+                lines=["No world selected"],
+            )
+            rules_f = FrameVM(id="rules", title="Rules", hotkey="r", lines=[""])
+            history_f = FrameVM(id="history", title="History", hotkey="h", lines=[""])
+            logs_f = FrameVM(id="logs", title="Step Logs", hotkey="l", lines=[""])
+            frames_no_world: List[FrameVM] = [
+                header_f,
+                worlds_f,
+                rules_f,
+                history_f,
+                logs_f,
+            ]
+            if selected_info:
+                frames_no_world.append(SelectedVM(text=selected_info).to_frame())
+            frames_no_world.append(FooterVM().to_frame())
+            return AsciiViewModel(frames=frames_no_world)
+
         active = len(world.hex.get_active_cells())
 
         header_f = HeaderVM().to_frame()

--- a/tests/ascii_samples.py
+++ b/tests/ascii_samples.py
@@ -1,0 +1,75 @@
+from infrastructure.ui.hexios.desktop.ascii.viewmodel import AsciiViewModel, FrameVM
+from infrastructure.ui.hexios.desktop.ascii.renderer import (
+    GridLayoutSpec,
+    SelectionState,
+)
+from typing import List, Tuple
+
+
+def sample_border() -> Tuple[AsciiViewModel, GridLayoutSpec, SelectionState, List[str]]:
+    vm = AsciiViewModel(frames=[FrameVM(id="header", title="A", hotkey="", lines=[""])])
+    layout = GridLayoutSpec(
+        width=7,
+        height=3,
+        header=(0, 0, 7, 3),
+        worlds=(0, 0, 0, 0),
+        rules=(0, 0, 0, 0),
+        history=(0, 0, 0, 0),
+        logs=(0, 0, 0, 0),
+        selected=(0, 0, 0, 0),
+        footer=(0, 0, 0, 0),
+    )
+    selection = SelectionState(mode="top")
+    expected = ["┌─ A ─┐", "│     │", "└─────┘"]
+    return vm, layout, selection, expected
+
+
+def sample_text() -> Tuple[AsciiViewModel, GridLayoutSpec, SelectionState, List[str]]:
+    vm = AsciiViewModel(
+        frames=[FrameVM(id="worlds", title="T", hotkey="", lines=["abc", "defg"])]
+    )
+    layout = GridLayoutSpec(
+        width=10,
+        height=5,
+        header=(0, 0, 0, 0),
+        worlds=(0, 0, 10, 5),
+        rules=(0, 0, 0, 0),
+        history=(0, 0, 0, 0),
+        logs=(0, 0, 0, 0),
+        selected=(0, 0, 0, 0),
+        footer=(0, 0, 0, 0),
+    )
+    selection = SelectionState(mode="top")
+    expected = [
+        "┌── T ───┐",
+        "│abc     │",
+        "│defg    │",
+        "│        │",
+        "└────────┘",
+    ]
+    return vm, layout, selection, expected
+
+
+def sample_selection() -> (
+    Tuple[AsciiViewModel, GridLayoutSpec, SelectionState, List[str]]
+):
+    vm = AsciiViewModel(
+        frames=[
+            FrameVM(id="worlds", title="W", hotkey="", lines=[""]),
+            FrameVM(id="rules", title="R", hotkey="", lines=[""]),
+        ]
+    )
+    layout = GridLayoutSpec(
+        width=14,
+        height=3,
+        header=(0, 0, 0, 0),
+        worlds=(0, 0, 7, 3),
+        rules=(7, 0, 7, 3),
+        history=(0, 0, 0, 0),
+        logs=(0, 0, 0, 0),
+        selected=(0, 0, 0, 0),
+        footer=(0, 0, 0, 0),
+    )
+    selection = SelectionState(mode="frame", frame_id="worlds")
+    expected = ["┌─ W ─┐┌─ R ─┐", "│     ││     │", "└─────┘└─────┘"]
+    return vm, layout, selection, expected

--- a/tests/test_ascii_renderer.py
+++ b/tests/test_ascii_renderer.py
@@ -1,0 +1,29 @@
+import unittest
+from infrastructure.ui.hexios.desktop.ascii.renderer import AsciiRenderer
+from tests.ascii_samples import sample_border, sample_selection, sample_text
+
+
+class TestAsciiRenderer(unittest.TestCase):
+    def test_border_rendering(self) -> None:
+        vm, layout, selection, expected = sample_border()
+        renderer = AsciiRenderer(vm, layout, selection)
+        lines, _ = renderer.render()
+        self.assertEqual(lines, expected)
+
+    def test_text_rendering(self) -> None:
+        vm, layout, selection, expected = sample_text()
+        renderer = AsciiRenderer(vm, layout, selection)
+        lines, _ = renderer.render()
+        self.assertEqual(lines, expected)
+
+    def test_selection_tag(self) -> None:
+        vm, layout, selection, expected = sample_selection()
+        renderer = AsciiRenderer(vm, layout, selection)
+        lines, tags = renderer.render()
+        self.assertEqual(lines, expected)
+        self.assertIn((0, 7, "border_sel"), tags[0])
+        self.assertIn((7, 14, "border"), tags[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ascii_ui.py
+++ b/tests/test_ascii_ui.py
@@ -24,6 +24,16 @@ class TestAsciiUI(unittest.TestCase):
         width = max(len(line) for line in lines)
         self.assertEqual(width, panel.width)
 
+    def test_render_no_world(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["HEXI_DATA_DIR"] = tmp
+            controller = WorldService()
+            panel = AsciiControlPanel(controller, lambda: None)
+            lines = panel.render().splitlines()
+            width = max(len(line) for line in lines)
+            self.assertEqual(width, panel.width)
+            self.assertIn("No world selected", panel.render())
+
     def test_run_commands(self) -> None:
         world = self.controller.get_current_world()
         world.hex.set_cell(0, 0, "a")


### PR DESCRIPTION
## Summary
- Avoid crash when no world is selected by rendering placeholder frames in the ASCII control panel
- Document placeholder behavior and per-character tagged output in functional requirements
- Test rendering when no world is available
- Verify ASCII renderer borders, text, and selection using sample data

## Testing
- `python tools/run_tests.py --no-gui`
- `HEXIRULES_NO_GUI=1 python tools/check_quality.py`


------
https://chatgpt.com/codex/tasks/task_e_68af1b1d16cc83259dfd26859739892a